### PR TITLE
Hotfix Button add to cart

### DIFF
--- a/src/components/Cart/Cart.js
+++ b/src/components/Cart/Cart.js
@@ -33,9 +33,7 @@ const Cart = ({ updateCartStore }) => {
   }
 };
 
-const mapStateToProps = state => ({});
-
 export default connect(
-  mapStateToProps,
+  null,
   { updateCartStore }
 )(Cart);

--- a/src/components/Cart/CartProducts/PlusLessButtons/PlusLessButtons.jsx
+++ b/src/components/Cart/CartProducts/PlusLessButtons/PlusLessButtons.jsx
@@ -32,9 +32,7 @@ const PlusLessButtons = ({ data, uploadAndUpdateCart }) => {
   );
 };
 
-const mapStateToProps = state => ({});
-
 export default connect(
-  mapStateToProps,
+  null,
   { uploadAndUpdateCart }
 )(PlusLessButtons);

--- a/src/components/Cart/CartProducts/SingleProduct.jsx
+++ b/src/components/Cart/CartProducts/SingleProduct.jsx
@@ -43,9 +43,7 @@ const SingleProduct = ({ data, uploadAndUpdateCart }) => {
   );
 };
 
-const mapStateToProps = state => ({});
-
 export default connect(
-  mapStateToProps,
+  null,
   { uploadAndUpdateCart }
 )(SingleProduct);

--- a/src/components/Home/Products/ProductCard.js
+++ b/src/components/Home/Products/ProductCard.js
@@ -1,11 +1,12 @@
 import React from "react";
 import { Link } from "react-router-dom";
+import { connect } from "react-redux";
 import { FaCartPlus } from "react-icons/fa";
 import "./ProductCard.css";
 import { addProductToCart } from "../../Cart/ProductsManager";
 import { uploadAndUpdateCart } from "../../../actions/creators/cart";
 
-const ProductCard = ({ product }) => {
+const ProductCard = ({ product, uploadAndUpdateCart }) => {
   return (
     <div className="container-fluid row-eq-height">
       <div className="row my-1 product-card highlight">
@@ -47,4 +48,7 @@ const ProductCard = ({ product }) => {
   );
 };
 
-export default ProductCard;
+export default connect(
+  null,
+  { uploadAndUpdateCart }
+)(ProductCard);

--- a/src/components/Home/Products/ProductDetails/ProductsDetails.jsx
+++ b/src/components/Home/Products/ProductDetails/ProductsDetails.jsx
@@ -104,9 +104,7 @@ const ProductDetails = ({ match, uploadAndUpdateCart }) => {
   }
 };
 
-const mapStateToProps = state => ({});
-
 export default connect(
-  mapStateToProps,
+  null,
   { uploadAndUpdateCart }
 )(ProductDetails);

--- a/src/components/Routes/UserRoute.js
+++ b/src/components/Routes/UserRoute.js
@@ -51,9 +51,7 @@ const UserRoute = ({ component: Component, getUser, updateCartStore }) => {
   }
 };
 
-const mapStateToProps = state => ({});
-
 export default connect(
-  mapStateToProps,
+  null,
   { getUser, updateCartStore }
 )(UserRoute);


### PR DESCRIPTION
Fix: Now a logued in user can add products to it's cart in the home page after it adds more units of a product in the cart page.
Fix: Removed some useless lines of mapStateToProps.